### PR TITLE
Removed Whitespace in Package Name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": " @juspay/simple-card-validator",
+  "name": "@juspay/simple-card-validator",
   "version": "1.2.1",
   "description": "Card validation helpers for card number, expiry and CVV.",
   "main": "index.js",


### PR DESCRIPTION
The whitespace in the package.json name caused issues when installing with yarn.

> error  @juspay/simple-card-validator@1.2.1: Name contains illegal characters